### PR TITLE
Closes #5: The aggregated diff window should not scroll with the commit lists

### DIFF
--- a/src/ui/scss/main.scss
+++ b/src/ui/scss/main.scss
@@ -1039,6 +1039,9 @@ ul {
 }
 #logs-container {
     width: 100%;
+    #commit-logs-table-container {
+        overflow-y: auto;
+    }
     tr {
         width: 100%;
         :hover {

--- a/src/ui/search/app.ts
+++ b/src/ui/search/app.ts
@@ -42,6 +42,7 @@ interface TreeDataArray {
 }
 
 export class CommitSearches extends App<CommitSearchBootstrap> {
+    protected innerHeight: any;
     protected searchText: HTMLInputElement | null = null;
 
     constructor() {
@@ -49,6 +50,14 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
     }
 
     protected onInitialize() {
+        /**
+         * Here we're setting the max-height value of the commit logs table
+         * to 65% of the content height
+         * So if the height of the table exceeds this value, user will be able to scroll down
+         */
+        this.innerHeight = window.innerHeight;
+        const commitLogList = DOM.getElementById<HTMLDivElement>('commit-logs-table-container');
+        commitLogList.style.maxHeight = `${65 * this.innerHeight / 100}px`;
 
         const searchText = DOM.getElementById<HTMLInputElement>('searchText');
         this.searchText = searchText;

--- a/src/ui/search/app.ts
+++ b/src/ui/search/app.ts
@@ -49,6 +49,28 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
         super('CommitSearches', bootstrap);
     }
 
+    /**
+     * This function checks if the commit details section's (right side) height exceeds
+     * the default (65% * innerHeight) value of the commit list table.
+     *
+     * If so, sets the commit list's height to that value so that
+     * both tables will grow in sync. Otherwise sets the default value.
+     *
+     * @param logsContainer The Container Div Element for the entire section
+     * @param detailsContainer The Container Div element for the commit details (right side)
+     */
+    protected adjustHeight(logsContainer: HTMLDivElement, detailsContainer: HTMLDivElement) {
+        this.innerHeight = window.innerHeight;
+        const logsContainerHeight = +logsContainer.style.maxHeight!.replace('px', '');
+
+        if (detailsContainer.scrollHeight > logsContainerHeight) {
+            logsContainer.style.maxHeight = `${detailsContainer.scrollHeight}px`;
+        }
+        else {
+            logsContainer.style.maxHeight = `${65 * this.innerHeight / 100}px`;
+        }
+    }
+
     protected onInitialize() {
         /**
          * Here we're setting the max-height value of the commit logs table
@@ -58,6 +80,8 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
         this.innerHeight = window.innerHeight;
         const commitLogList = DOM.getElementById<HTMLDivElement>('commit-logs-table-container');
         commitLogList.style.maxHeight = `${65 * this.innerHeight / 100}px`;
+
+        const tablesContainer = DOM.getElementById<HTMLDivElement>('logs-container');
 
         const searchText = DOM.getElementById<HTMLInputElement>('searchText');
         this.searchText = searchText;
@@ -245,6 +269,8 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
                                 }
                             });
                         }
+
+                    this.adjustHeight(commitLogList, tablesContainer);
                     };
 
                     const seperator = list.insertRow();

--- a/src/ui/search/index.html
+++ b/src/ui/search/index.html
@@ -49,7 +49,7 @@
                 <div id="logs-container">
                     <table>
                         <tr>
-                            <td style="width:75%">
+                            <td style="width:75%; vertical-align: top;">
                                 <div id="commit-logs-table-container">
                                     <table id='logs' class="logs" style="width:100%">
                                         <tbody>

--- a/src/ui/search/index.html
+++ b/src/ui/search/index.html
@@ -50,16 +50,18 @@
                     <table>
                         <tr>
                             <td style="width:75%">
+                                <div id="commit-logs-table-container">
                                     <table id='logs' class="logs" style="width:100%">
-                                            <tbody>
-                                                <tr>
-                                                    <td>Hey Hey</td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
+                                        <tbody>
+                                            <tr>
+                                                <td>Hey Hey</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
                             </td>
                             <td style="width:25%; vertical-align:top">
-                                <div id='selected-files' class="logs"></div>
+                                 <div id='selected-files' class="logs"></div>
                                 <div id='selected-commits' class="logs"></div>
                             </td>
                         </tr>


### PR DESCRIPTION
Fix for the #5 has been implemented. Scrolling support in the Commit Search has been enhanced. Users are now able to scroll down the commit log list, while header and details section stay visible.

Demo: https://youtu.be/53ynRwXT8cI