### PR TITLE
Closes #10: Add an icon to denote which line has a comment.

### DIFF
--- a/src/annotations/commentsDecoratorController.ts
+++ b/src/annotations/commentsDecoratorController.ts
@@ -1,0 +1,117 @@
+'use strict';
+import * as path from 'path';
+import { DecorationOptions, Disposable, OverviewRulerLane, Range, TextEditor, window } from 'vscode';
+import { Container } from '../container';
+import { GitCommit } from '../git/git';
+import { Comment, CommentType, GitCommentService } from '../gitCommentService';
+import { GitUri } from '../gitService';
+
+interface CommitDic {
+    [key: string]: GitCommit;
+}
+
+export class CommentsDecoratorController implements Disposable {
+    private _disposable: Disposable;
+    private _activeEditor: TextEditor | undefined;
+    private _activeFilename: string | undefined;
+
+    private bookmarkDecorationType = window.createTextEditorDecorationType({
+        gutterIconPath: Container.context.asAbsolutePath('images/bookmark.svg'),
+        overviewRulerLane: OverviewRulerLane.Full,
+        overviewRulerColor: 'rgba(21, 126, 251, 0.7)'
+    });
+    decorations: DecorationOptions[] = [];
+
+    constructor() {
+        this._activeEditor = window.activeTextEditor;
+        if (this._activeEditor) {
+            this.fetchComments();
+        }
+
+        this._disposable = Disposable.from(
+            window.onDidChangeActiveTextEditor(editor => {
+                this._activeEditor = editor;
+                if (editor) {
+                    this.fetchComments();
+                }
+            }, null)
+        );
+    }
+
+    dispose() {
+        Container.lineTracker.stop(this);
+        this._disposable && this._disposable.dispose();
+    }
+
+    /**
+     * Creates a list of the existing commits (no-duplicate) in the active file.
+     */
+    async fetchComments() {
+        console.log('fetch');
+        if (!GitCommentService.isLoggedIn()) {
+            console.log('not logged in');
+            return;
+        }
+
+        if (this._activeEditor) {
+            this.decorations = [];
+            const gitUri = await GitUri.fromUri(this._activeEditor.document.uri);
+            this._activeFilename = path.relative(gitUri.repoPath ? gitUri.repoPath : '', gitUri.fsPath);
+            this._activeFilename = this.normalizePath(this._activeFilename);
+            const count = this._activeEditor.document.lineCount;
+            const commitSha: CommitDic = {};
+            const trackedDocument = await Container.tracker.getOrAdd(this._activeEditor.document);
+            for (let i = 0; i < count; i++) {
+                const blameLine = this._activeEditor.document.isDirty
+                    ? await Container.git.getBlameForLineContents(
+                          trackedDocument.uri,
+                          i,
+                          this._activeEditor.document.getText()
+                      )
+                    : await Container.git.getBlameForLine(trackedDocument.uri, i);
+                if (blameLine === undefined) continue;
+                const commit = blameLine.commit;
+
+                if (commit === undefined || commitSha[commit.sha]) continue;
+                commitSha[commit.sha] = commit;
+            }
+
+            Object.values(commitSha).map(async commit => {
+                let comments = await Container.commentService.loadComments(commit);
+                if (comments === undefined) return;
+                comments = comments.filter(
+                    c => c.Type === CommentType.Line && c.Commit && this._activeFilename === c.Path
+                );
+                this.updateDecorations(comments);
+            });
+        }
+    }
+
+    /**
+     * Takes comment list, and denotes the corresponding lines of comments
+     * with an icon.
+     * @param comments: Comment[] Comment list of the current file
+     */
+    updateDecorations(comments: Comment[]) {
+        if (!this._activeEditor) {
+            return;
+        }
+        for (const comment of comments) {
+            const line = comment.Line!;
+            const decoration = { range: new Range(line, 0, line, 0) };
+            this.decorations.push(decoration);
+        }
+        this._activeEditor.setDecorations(this.bookmarkDecorationType, this.decorations);
+    }
+
+    /**
+     * BitBucket API returns paths with forward slashes.
+     * like 'dir/file.ext'
+     *
+     * If our OS is treating with backslashes 'dir\file.ext', we need to convert them
+     * @param path Active file name
+     */
+    normalizePath(path: string) {
+        return path.replace('\\', '/');
+    }
+}

--- a/src/commands/addLineComments.ts
+++ b/src/commands/addLineComments.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { CancellationTokenSource, InputBoxOptions, TextEditor, Uri, window } from 'vscode';
+import { CancellationTokenSource, TextEditor, Uri, window } from 'vscode';
 import { GlyphChars } from '../constants';
 import { Container } from '../container';
 import { Comment, CommentType } from '../gitCommentService';
@@ -275,7 +275,12 @@ export class AddLineCommentCommand extends ActiveEditorCachedCommand {
                         placeHolder: 'Are you sure you want to delete this comment (Yes/No)?',
                         ignoreFocusOut: true
                     });
-                    if (pick! === 'Yes') Container.commentService.deleteComment(args.commit!, args.id);
+                    if (pick! === 'Yes') {
+                        Container.commentService.deleteComment(args.commit!, args.id)
+                        .then(() => {
+                            Container.commentsDecorator.fetchComments();
+                        });
+                    }
                 }
             }
             else {
@@ -300,7 +305,9 @@ export class AddLineCommentCommand extends ActiveEditorCachedCommand {
                             commentText as string,
                             args.fileName as string,
                             args.line
-                        );
+                        ).then(() => {
+                            Container.commentsDecorator.fetchComments();
+                        });
                     }
                     // decreasing the runningAppCount by 1
                     const decreasedCount = commentAppHelper.runningAppCount - 1;

--- a/src/container.ts
+++ b/src/container.ts
@@ -20,6 +20,7 @@ import { ResultsExplorer } from './views/resultsExplorer';
 import { SearchEditor } from './webviews/searchEditor';
 import { SettingsEditor } from './webviews/settingsEditor';
 import { WelcomeEditor } from './webviews/welcomeEditor';
+import { CommentsDecoratorController } from './annotations/commentsDecoratorController';
 
 export class Container {
     static initialize(context: ExtensionContext, config: IConfig) {
@@ -34,6 +35,7 @@ export class Container {
         // Since there is a bit of a chicken & egg problem with the DocumentTracker and the GitService, initialize the tracker once the GitService is loaded
         this._tracker.initialize();
 
+        context.subscriptions.push((this._commentsDecoratorController = new CommentsDecoratorController()));
         context.subscriptions.push((this._fileAnnotationController = new FileAnnotationController()));
         context.subscriptions.push((this._lineAnnotationController = new LineAnnotationController()));
         context.subscriptions.push((this._lineHoverController = new LineHoverController()));
@@ -117,6 +119,11 @@ export class Container {
     private static _commentService: GitCommentService;
     static get commentService() {
         return this._commentService;
+    }
+
+    private static _commentsDecoratorController: CommentsDecoratorController;
+    static get commentsDecorator() {
+        return this._commentsDecoratorController;
     }
 
     private static _gitExplorer: GitExplorer | undefined;

--- a/src/gitCommentService.ts
+++ b/src/gitCommentService.ts
@@ -8,7 +8,6 @@ import { GitCommit } from './git/models/commit';
 import { Logger } from './logger';
 import { AddLineCommentCommand } from './commands/addLineComments';
 import { GitUri } from './git/gitUri';
-import { ShowDiffMessage } from './ui/ipc';
 
 /**
  * Enum to for different comment types.
@@ -152,6 +151,19 @@ export class GitCommentService implements Disposable {
     }
 
     /**
+     * true if user logged in to bitbucket,
+     * false otherwise
+     */
+    static isLoggedIn(): boolean {
+        if (!GitCommentService.username || !GitCommentService.password) {
+            return false;
+        }
+        else {
+            return true;
+        }
+    }
+
+    /**
      * Prompts user to enter remote repository credentials.
      */
     private static async getCredentials(): Promise<AxiosBasicCredentials> {
@@ -195,12 +207,17 @@ export class GitCommentService implements Disposable {
                                 comment.Id = c.id;
                             }
                             //  if (c.inline && c.inline.to !== undefined) {
-                            comment.Line = (c.inline.to as number)! - 1;
-                            if (comment.Line === -1) {
-                                comment.Type = CommentType.File;
+                            //comment.Line = (c.inline.to as number)! - 1;
+
+                            // If comment is a file comment, there is no inline field.
+                            // Therefore it enters the catch block with above usage.
+                            // this prevents the rest of comments from being loaded
+                            if (c.inline && c.inline.to && c.inline.to > 0) {
+                                comment.Line = c.inline.to - 1;
+                                comment.Type = CommentType.Line;
                             }
                             else {
-                                comment.Type = CommentType.Line;
+                                comment.Type = CommentType.File;
                             }
                             // }
                             if (c.inline && c.inline.path) {
@@ -244,6 +261,7 @@ export class GitCommentService implements Disposable {
                     return result;
                 })
                 .catch(e => {
+                    console.log(e);
                     if (e!.response!.status === 401 || e!.response!.status === 403) {
                         window.showErrorMessage('Incorrect Bit Bucket Service Credentials.');
                         GitCommentService.ClearCredentials();


### PR DESCRIPTION
Issue #10 Add an icon to denote which line has a comment.

The lines have inline comments now will be denoted with an icon. 

Demonstration: https://youtu.be/HnhMSG4Y1bw

The (BitBucket) API requests are asynchronous. The trigger of the fetching function is [windows.onDidChangeActiveTextEditor](https://code.visualstudio.com/docs/extensionAPI/vscode-api#_window) event.

Proposals for future work:

1. Currently it processes all lines of the active file. If the files is too big, (suppose thousands of lines), instead of all lines, [window.onDidChangeTextEditorVisibleRanges ](https://code.visualstudio.com/docs/extensionAPI/vscode-api#_window) may be considered. Only visible lines to user will be processed with this way.

2. As mentioned above, the trigger event is [windows.onDidChangeActiveTextEditor](https://code.visualstudio.com/docs/extensionAPI/vscode-api#_window) event. This means, every time you change the active editor tab, close/open a new file in the editor, all the lines of the file will be processed again. This may be negative if the user is working with too many files open. [onDidChangeVisibleTextEditors](url) event might be considered. All open documents can be reachable with this event, denotation of the other open files may be completed in background.
