### PR TITLE
Fix fold and unfold folder in tree view

### DIFF
--- a/src/ui/search/app.ts
+++ b/src/ui/search/app.ts
@@ -261,7 +261,7 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
                         // All nodes are expanded
                         const treeHtml = document.querySelectorAll('ul.tree a:not(:last-child)');
                         for (const treeNode of treeHtml) {
-                            treeNode.addEventListener('click', function(e) {
+                            treeNode.addEventListener('click', event => {
                                 const parent  = (event.target as HTMLElement)['parentElement'] as HTMLElement;
                                 const classList = parent.classList;
                                 if (classList.contains('open')) {
@@ -394,11 +394,13 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
             } catch (error) {
                 // params = undefined;
             }
-            a.onclick = () => {
-                if (params) {
-                    this._api.postMessage(params);
-                }
-            };
+            if (item.details && item.details.length === 1) {
+                a.onclick = () => {
+                    if (params) {
+                        this._api.postMessage(params);
+                    }
+                };
+            }
             a.innerText = `${item.title}`;
             li.appendChild(a);
             selectedFiles.appendChild(li);


### PR DESCRIPTION
## Describe the bug
Currently, the folder in the tree nodes can't be folded or expanded. We should support this feature.
To Reproduce
Steps to reproduce the behavior:

## Go to the GitLens options
- Click on the search button to open the new UI
- Select one or several commits.
- Click the folder in the file tree nodes
- The folder can't be folded or expanded, and an error message is prompted.

## Expected behavior
The folder should be folded or expanded by clicking it.

## Screenshots
See https://monosnap.com/file/K1y00oQvQ2jw7SURdbnQcs8YmsFm9g