### PR TITLE
Tweak show merge commits

### DIFF
--- a/search.html
+++ b/search.html
@@ -80,7 +80,7 @@
 
                     <label class="control control--checkbox">
                         Show Merge Commits
-                        <input type="checkbox" id="showMergeCommits" />
+                        <input type="checkbox" id="showMergeCommits" checked />
                         <div class="control__indicator"></div>
                     </label>
                     <input type="text" id="after" placeholder="after" title="after" onfocus="(this.type='date')" onblur="(this.type='text')" />
@@ -96,7 +96,7 @@
                             <table id='logs' class="logs" style="width:100%">
                                 <tbody>
                                     <tr>
-                                        <td>Hey Hey</td>
+                                        <td>Loading...</td>
                                     </tr>
                                 </tbody>
                             </table>

--- a/src/gitService.ts
+++ b/src/gitService.ts
@@ -1162,7 +1162,7 @@ export class GitService implements Disposable {
     async getLogForSearch(
         repoPath: string,
         searchByMap: Map<GitRepoSearchBy, string>,
-        options: { maxCount?: number, showMergeCommits?: boolean } = {}
+        options: { maxCount?: number; showMergeCommits?: boolean } = {}
     ): Promise<GitLog | undefined> {
         Logger.log(`getLogForSearch('${repoPath}', '${searchByMap}', ${options.maxCount})`);
 
@@ -1216,7 +1216,7 @@ export class GitService implements Disposable {
             }
             searchArgs = [...searchArgs, ...args];
 
-            if (!options.showMergeCommits) {
+            if (!options.showMergeCommits && options.showMergeCommits !== undefined) {
                 searchArgs = [...searchArgs, '--no-merges'];
             }
         });

--- a/src/ui/scss/main.scss
+++ b/src/ui/scss/main.scss
@@ -1063,7 +1063,13 @@ ul {
         }
     }
     .commit-label{
+        display: flex;
+        align-items: center;
         font-weight: bold;
+        .icon-merge {
+            font-size: 21px;
+            margin-right: 4px;
+        }
     }
     .details-row{
         padding: 100px;

--- a/src/ui/search/app.ts
+++ b/src/ui/search/app.ts
@@ -163,7 +163,8 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
             dataMsg.forEach((element, rId) => {
                 const r1 = list.insertRow();
                 const c1 = r1.insertCell();
-                c1.innerHTML = `<div class='commit-label'> ${element.label} </div> <div> ${element.description}</div>
+                const isMergeCommits = element.hasOwnProperty('commit') && element.commit.parentShas.length > 1;
+                c1.innerHTML = `<div class='commit-label'> ${isMergeCommits ? `<span class="icon-merge">Ⓜ</span>` : ''} ${element.label} </div> <div> ${element.description}</div>
                 `;
 
                 if (!element.commit) {
@@ -417,22 +418,30 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
     protected onBind() {
         const that = this;
         DOM.listenAll('.postme', 'click', function(this: HTMLButtonElement) {
-            const searchText = DOM.getElementById<HTMLInputElement>('searchText')!.value;
-            const author = DOM.getElementById<HTMLInputElement>('author')!.value;
-            const before = DOM.getElementById<HTMLInputElement>('before')!.value;
-            const after = DOM.getElementById<HTMLInputElement>('after')!.value;
-            const showMergeCommits = DOM.getElementById<HTMLInputElement>('showMergeCommits')!.checked;
-            that._api.postMessage({
-                type: 'search',
-                search: searchText,
-                branch: that.getBranch(),
-                author: author,
-                since: that.getSince(),
-                before: before,
-                after: after,
-                showMergeCommits: showMergeCommits
-            });
+            that.doSearch();
         });
+
+        DOM.listenAll('#showMergeCommits', 'change', function(this: HTMLButtonElement) {
+            that.doSearch();
+        });
+   }
+
+   protected doSearch() {
+       const searchText = DOM.getElementById<HTMLInputElement>('searchText')!.value;
+       const author = DOM.getElementById<HTMLInputElement>('author')!.value;
+       const before = DOM.getElementById<HTMLInputElement>('before')!.value;
+       const after = DOM.getElementById<HTMLInputElement>('after')!.value;
+       const showMergeCommits = DOM.getElementById<HTMLInputElement>('showMergeCommits')!.checked;
+       this._api.postMessage({
+           type: 'search',
+           search: searchText,
+           branch: this.getBranch(),
+           author: author,
+           since: this.getSince(),
+           before: before,
+           after: after,
+           showMergeCommits: showMergeCommits
+       });
    }
 
     protected getBranch(): string {

--- a/src/ui/search/index.html
+++ b/src/ui/search/index.html
@@ -80,7 +80,7 @@
 
                     <label class="control control--checkbox">
                         Show Merge Commits
-                        <input type="checkbox" id="showMergeCommits" />
+                        <input type="checkbox" id="showMergeCommits" checked />
                         <div class="control__indicator"></div>
                     </label>
                     <input type="text" id="after" placeholder="after" title="after" onfocus="(this.type='date')" onblur="(this.type='text')" />
@@ -96,7 +96,7 @@
                             <table id='logs' class="logs" style="width:100%">
                                 <tbody>
                                     <tr>
-                                        <td>Hey Hey</td>
+                                        <td>Loading...</td>
                                     </tr>
                                 </tbody>
                             </table>


### PR DESCRIPTION
We would like to do some tweaks to make the user experience better.
(1) Add an icon Ⓜ in front of the merge commit. You can use this special character as the icon.
So that the merge commits are easily recognizable.
(2) Make the "Show Merge Commits" checkbox checked by default, so that we can show all commits by default.
(3) Currently, if we need to hide/show merge commits, we need to uncheck/check the "Show Merge Commits" checkbox then click the "Search" button. It's too cumbersome. Let's simplify the step by just unchecking/checking the checkbox. That is, uncheck/check the "Show Merge Commits" checkbox should hide/show merge commits, no need to click the "Search" button anymore.