### PR TITLE
Fix text wrap

### DIFF
--- a/src/ui/scss/main.scss
+++ b/src/ui/scss/main.scss
@@ -1073,6 +1073,19 @@ ul {
     }
 }
 
+
+table#logs {
+ width: 100%;
+ table-layout: fixed;
+    td {
+        width: 100%;
+        white-space: -o-pre-wrap;
+        word-wrap: break-word;
+        white-space: pre-wrap;
+        white-space: -moz-pre-wrap;
+    }
+}
+
 ul.tree {
 	padding: 5px;
 	margin: 5px;

--- a/src/ui/search/app.ts
+++ b/src/ui/search/app.ts
@@ -163,8 +163,7 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
             dataMsg.forEach((element, rId) => {
                 const r1 = list.insertRow();
                 const c1 = r1.insertCell();
-                c1.innerHTML = `<div class='commit-label'> ${element.label} </div> <div> ${element.description}</div>
-                `;
+                c1.innerHTML = `<div class='commit-label'>${element.label}</div><div>${element.description}</div>`;
 
                 if (!element.commit) {
                     r1.hidden = true;


### PR DESCRIPTION
We added a bar to resize the width of the left/right panel of the search view, see #23 (closed)
But after this fix, the texts of commits in the left never wrap, instead, the panel is horizontally scrollable.