### PR TITLE
Implemented CommentCache mechanism and made some improvements

### DIFF
--- a/src/commands/addLineComments.ts
+++ b/src/commands/addLineComments.ts
@@ -88,7 +88,11 @@ export class AddLineCommentCommand extends ActiveEditorCachedCommand {
                     commentArgs.fileName as string,
                     commentArgs.line
                 );
-                await Container.commentsDecorator.fetchComments();
+
+                // add decoration for new comment
+                let newComment = new Comment();
+                newComment.Line = commentArgs.line;
+                Container.commentsDecorator.updateDecorations([newComment]);
             }
             else if (commentArgs.type === operationTypes.Reply) {
                 // reply

--- a/src/gitCommentService.ts
+++ b/src/gitCommentService.ts
@@ -44,7 +44,7 @@ export class Comment {
  * Since this class stores Comment objects, it's very flexible and can be used
  * in any part that needs comments.
  */
-class CommentCacheItem {
+export class CommentCacheItem {
     Comments: Comment[];
     FetchedTime: number;
     constructor(comments: Comment[]) {
@@ -411,8 +411,10 @@ export class GitCommentService implements Disposable {
                     next = null;
                 });
         }
-        let cacheItem = new CommentCacheItem(result);
-        this.commentCache.CachedItems.set(sha, cacheItem);
+        if (result) {
+            const cacheItem = new CommentCacheItem(result);
+            this.commentCache.CachedItems.set(sha, cacheItem);
+        }
         return result.filter(c => c.ParentId === undefined);
     }
 

--- a/src/gitCommentService.ts
+++ b/src/gitCommentService.ts
@@ -37,6 +37,31 @@ export class Comment {
 }
 
 /**
+ * Stores comment list against commit hash
+ * for the CacheTimeout (5 minutes default)
+ * You may adjust CacheTimeout for your need in minutes format.
+ *
+ * Since this class stores Comment objects, it's very flexible and can be used
+ * in any part that needs comments.
+ */
+class CommentCacheItem {
+    Comments: Comment[];
+    FetchedTime: number;
+    constructor(comments: Comment[]) {
+        this.Comments = comments;
+        this.FetchedTime = Date.now();
+    }
+}
+
+export class CommentCache {
+    static CacheTimeout = 5; // minutes
+    CachedItems: Map<string, CommentCacheItem>;
+    constructor() {
+        this.CachedItems = new Map<string, CommentCacheItem>();
+    }
+}
+
+/**
  * The service that communicates with remote repository store.
  */
 export class GitCommentService implements Disposable {
@@ -62,10 +87,13 @@ export class GitCommentService implements Disposable {
     public static commentViewerCommit: GitCommit;
     public static commentViewerFilename: string;
 
+    public commentCache: CommentCache;
+
     constructor() {
         commands.registerCommand('gitlens.commentCommitFile', this.commentToFile, this);
         commands.registerCommand('gitlens.showCommentCommitFile', this.showFileComment, this);
         commands.registerCommand('gitlens.showCommentCommitLine', this.showLineComment, this);
+        this.commentCache = new CommentCache();
     }
 
     async commentToFile() {
@@ -360,7 +388,6 @@ export class GitCommentService implements Disposable {
                             }
 
                             commentsMap.set(isV2 ? c.id : c.comment_id, comment);
-
                             result.push(comment);
                         }
                     });
@@ -384,6 +411,8 @@ export class GitCommentService implements Disposable {
                     next = null;
                 });
         }
+        let cacheItem = new CommentCacheItem(result);
+        this.commentCache.CachedItems.set(sha, cacheItem);
         return result.filter(c => c.ParentId === undefined);
     }
 


### PR DESCRIPTION
-  [x]  Implemented a CommentCache mechanism that stores Comments against commits, when loadComment method executed.
*  *  CacheTimeout is default 5 minutes. If line's commit (so Comment[]) doesn't cached, or CommentCache.FetchedTime exceeds 5 minutes from Date.now, that commit will be fetched again.
*  *  Otherwise the value in the memory will be used.
-  [x]  Now duplicate entries will not be added as multiple line decorations. Even though one line has more than one comment, it will be added only once.
-  [x]  After adding new comment, now it denotes only that line instead of fetching/iterating all lines again.


-  [x]  Some console.log lines deleted (unnecessary for production environment)

