### PR TITLE
Disabled cancellation check when comments are being loaded

### DIFF
--- a/src/commands/showCommitSearch.ts
+++ b/src/commands/showCommitSearch.ts
@@ -120,7 +120,10 @@ export class ShowCommitSearchCommand extends ActiveEditorCachedCommand {
                 showMergeCommits: args.showMergeCommits
             });
 
-            if (progressCancellation.token.isCancellationRequested) return undefined;
+            // clicking somewhere when commits are being loaded
+            // cancels the progress
+            // disabled cancellation check
+            // if (progressCancellation.token.isCancellationRequested) return undefined;
 
             const goBackCommand: CommandQuickPickItem | undefined =
                 args.goBackCommand ||


### PR DESCRIPTION
A workaround about the issue mentioned in https://gitlab.com/aggregated-git-diff/aggregated-git-diff-bug-bash/issues/50

