### PR TITLE
GitLab Ticket 54: Comment Editor is now being initializing with empty content

### DIFF
--- a/src/commands/addLineComments.ts
+++ b/src/commands/addLineComments.ts
@@ -130,7 +130,7 @@ export class AddLineCommentCommand extends ActiveEditorCachedCommand {
         }
         else if (data.id === commentApp.getConnectionString() && data.command === 'ui.ready') {
             const initText = commentArgs.type === operationTypes.Edit ? commentArgs.message! : '';
-            commentApp.initEditor(commentArgs.message!);
+            commentApp.initEditor(initText);
         }
         else if (data.id === commentApp.getConnectionString() && data.command === 'close') {
             commentApp.close();
@@ -148,9 +148,9 @@ export class AddLineCommentCommand extends ActiveEditorCachedCommand {
      * @param args Comment arguments
      */
     showOrRunApp(args: AddLineCommentsCommandArgs) {
+        const initText = args.type === operationTypes.Edit ? args.message! : '';
         if (commentApp && commentApp.isRunning() && commentApp.getKeepOpen()) {
             commentApp.setCommentArgs(args);
-            const initText = args.type === operationTypes.Edit ? args.message! : '';
             commentApp.initEditor(initText);
             commentApp.show();
         }
@@ -162,6 +162,7 @@ export class AddLineCommentCommand extends ActiveEditorCachedCommand {
             commentApp = new CommentApp(this.electronPath, this.BITBUCKET_COMMENT_APP_PATH, this.eventEmitter, args);
             commentApp.run();
             commentApp.setUpConnection();
+            commentApp.initEditor(initText)
         }
     }
 


### PR DESCRIPTION
GitLab Ticket 54: https://gitlab.com/aggregated-git-diff/aggregated-git-diff-bug-bash/issues/54

Fixed: Comment Editor is now being initializing with empty content when replying