### PR TITLE
Revert "Sync comments on right side of split diff view with left"

### DIFF
--- a/src/annotations/commentsDecoratorController.ts
+++ b/src/annotations/commentsDecoratorController.ts
@@ -138,11 +138,5 @@ export class CommentsDecoratorController implements Disposable {
             }
         }
         this._activeEditor.setDecorations(this.bookmarkDecorationType, this.decorations);
-        for (const editor of window.visibleTextEditors) {
-            if (editor.viewColumn === undefined && this._activeEditor !== editor) {
-                editor.setDecorations(this.bookmarkDecorationType, this.decorations);
-                break;
-            }
-        }
     }
 }


### PR DESCRIPTION
Reverts billsedison/vscode-gitlens#107

Revert this since it causes a weird problem. All menu items appear twice.

![image](https://user-images.githubusercontent.com/5657467/50376235-84adbf00-0645-11e9-9aa4-d64acd0c0845.png)
