### PR TITLE
Fixed the code syntax highlighting in the preview mode of comment editor

### DIFF
--- a/bitbucket-comment-app/index.html
+++ b/bitbucket-comment-app/index.html
@@ -55,6 +55,11 @@
     }
 
     renderer.text = linkText;
+    // syntax highlighting
+    function highlightSyntax(code) {
+      return hljs.highlightAuto(code).value;
+    }
+
 
     let markedOptions = {
         renderer,
@@ -64,7 +69,8 @@
         pedantic:    false,
         sanitize:    false,
         smartLists:  false,
-        smartypants: false
+        smartypants: false,
+        highlight: highlightSyntax
     };
 
     // Editor


### PR DESCRIPTION
![2018-12-24_18-53-11](https://user-images.githubusercontent.com/28513447/50403153-5fd45b80-07ad-11e9-98cf-9417aa7031e4.gif)

It was working with https://github.com/billsedison/vscode-gitlens/commit/f318dbe1a7da3fd9920a09213ce3f7cbe05d5a39, but with later changes (mention rendering) this feature had broken

This PR fixes this issue and integrates marked.js with highlight.js