### PR TITLE
Open links externally in the preview mode

### DIFF
--- a/bitbucket-comment-app/main.js
+++ b/bitbucket-comment-app/main.js
@@ -1,7 +1,7 @@
 // ipcMain and ipcRenderer for Communication between electron main/renderer processes
 // node-ipc for communication between electron and vscode extension host (they're independent processes)
 // electron's ipc modules are not helpful to send (or receive) data to external apps
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, shell } = require('electron');
 const ipc = require('node-ipc');
 
 // connectionString is an unique identifier for each process spawned (or ExternalApp instance)
@@ -50,6 +50,11 @@ function createWindow() {
     mainWindow.on('closed', function() {
         // globalShortcut.unregister('CommandOrControl+1');
         mainWindow = null;
+    });
+
+    mainWindow.webContents.on('new-window', function(e, url) {
+        e.preventDefault();
+        shell.openExternal(url);
     });
 
     // node-ipc configurations


### PR DESCRIPTION
Rendered mentions (or other links) in the preview mode of comment editor app were being opened as new window 

![2018-12-24_18-51-27](https://user-images.githubusercontent.com/28513447/50403331-d2920680-07ae-11e9-9d3b-dd6c1fe9ab1b.gif)

They will be opened externally in default browser with this PR. (same as the comment viewer app.)