### PR TITLE
Fix paths for cross-platform support

### DIFF
--- a/src/gitCommentService.ts
+++ b/src/gitCommentService.ts
@@ -291,7 +291,7 @@ export class GitCommentService implements Disposable {
      * @param pathToReplace
      */
     normalizeToForwardSlashes(pathToReplace: string): string {
-        return pathToReplace.replace('\\', '/');
+        return pathToReplace.replace(/\\/g, '/');
     }
 
     /**

--- a/src/gitCommentService.ts
+++ b/src/gitCommentService.ts
@@ -104,7 +104,7 @@ export class GitCommentService implements Disposable {
         const fileCommit = {
             sha: AddLineCommentCommand.currentFileCommit.rsha,
             repoPath: AddLineCommentCommand.currentFileCommit.repoPath,
-            fileName: filename
+            fileName: this.normalizeToForwardSlashes(filename)
         } as GitCommit;
 
         await GitCommentService.getCredentials();
@@ -119,7 +119,8 @@ export class GitCommentService implements Disposable {
     async showFileComment() {
         if (!AddLineCommentCommand.currentFileCommit || !window.activeTextEditor) return undefined;
         const gitUri = await GitUri.fromUri(window.activeTextEditor.document.uri);
-        const filename: string = path.relative(AddLineCommentCommand.currentFileCommit.repoPath, gitUri.fsPath);
+        let filename: string = path.relative(AddLineCommentCommand.currentFileCommit.repoPath, gitUri.fsPath);
+        filename = this.normalizeToForwardSlashes(filename);
 
         AddLineCommentCommand.currentFileName = filename;
 
@@ -190,7 +191,8 @@ export class GitCommentService implements Disposable {
         }
         if (!repoPath) return undefined;
         const gitUri = await GitUri.fromUri(window.activeTextEditor.document.uri);
-        const filename: string = path.relative(repoPath, gitUri.fsPath);
+        let filename: string = path.relative(repoPath, gitUri.fsPath);
+        filename = this.normalizeToForwardSlashes(filename);
 
         AddLineCommentCommand.currentFileName = filename;
 
@@ -285,6 +287,14 @@ export class GitCommentService implements Disposable {
     }
 
     /**
+     * Replaces backward slashes (\\) with forward slashes (/)
+     * @param pathToReplace
+     */
+    normalizeToForwardSlashes(pathToReplace: string): string {
+        return pathToReplace.replace('\\', '/');
+    }
+
+    /**
      * Loads all comments for the given commit (via API version 1).
      * @param commit commit
      */
@@ -292,14 +302,14 @@ export class GitCommentService implements Disposable {
         const isV2 = Container.config.advanced.useApiV2;
         const baseUrl = isV2 ? this.V2BaseURL : this.V1BaseURL;
 
-        const path = await this.getRemoteRepoPath(commit.repoPath);
-        if (!path) {
+        const repoPath = await this.getRemoteRepoPath(commit.repoPath);
+        if (!repoPath) {
             return;
         }
         const auth = await GitCommentService.getCredentials();
         const sha = commit.sha;
         const commitStr = isV2 ? 'commit' : 'changesets';
-        const url = `${baseUrl}/${path}/${commitStr}/${sha}/comments/`;
+        const url = `${baseUrl}/${repoPath}/${commitStr}/${sha}/comments/`;
         const requestParams = {
             pagelen: 100
         };
@@ -345,7 +355,7 @@ export class GitCommentService implements Disposable {
                                 }
 
                                 if (c.inline && c.inline.path) {
-                                    comment.Path = c.inline.path;
+                                    comment.Path = this.normalizeToForwardSlashes(c.inline.path);
                                 }
                                 if (c.commit && c.commit.hash) {
                                     comment.Sha = c.commit.hash;
@@ -374,7 +384,7 @@ export class GitCommentService implements Disposable {
                                 }
 
                                 if (c.filename) {
-                                    comment.Path = c.filename;
+                                    comment.Path = this.normalizeToForwardSlashes(c.filename);
                                 }
                                 if (c.node) {
                                     comment.Sha = c.node;
@@ -455,6 +465,7 @@ export class GitCommentService implements Disposable {
         if (!path) {
             return;
         }
+        fileName = this.normalizeToForwardSlashes(fileName);
         const auth = await GitCommentService.getCredentials();
         const sha = commit.sha;
         const commitStr = isV2 ? 'commit' : 'changesets';


### PR DESCRIPTION
https://gitlab.com/aggregated-git-diff/aggregated-git-diff-bug-bash/issues/85

> This will be happened if you have added comment from another platform
> 
> Windows treats paths with backward slashes like `src\commands\showCommitSearch.ts`
> 
> If you added a comment from Linux or macOS its added with forward slashes `src/commands/showCommitSearch.ts`
> 
> BitBucket also seems doesn't apply any normalization to paths, returns them as they are. So 
> * any comment added from Windows will be returned as `src\commands\showCommitSearch.ts`
> * any comment added from Linux or macOS will be returned as `src/commands/showCommitSearch.ts`
> 
> Therefore filtering operation returns wrong results
> 
> https://github.com/billsedison/vscode-gitlens/blob/tc-dev/src/gitCommentService.ts#L147
> https://github.com/billsedison/vscode-gitlens/blob/tc-dev/src/gitCommentService.ts#L215
> 
> In addition, comments with backward slashes **seem being returned from API endpoint** but **they are not being shown on the BitBucket website**. It's not consistent in itself. So best way was to replace bacward slashes with forward slashes
> 
> This is actally a serious issue I wonder how anyone hasn't realized this until now, maybe no one didn't test on multi platform.
> 
> I have included this in another PR, since it's not related to this and this PR already includes too many commits (might be confusing)
> 
> However, I'm not sure if there is any other part being affected from this issue It needs testing
> 
> One more thing, comment viewer app shows Edit and Delete buttons for all comments. But I'm not allowed to Edit or Delete someone else's comment. So if I try to do this, API returns 401 or 403 and extension thinks BitBucket credentials are wrong but the reality is API endpoint doesn't allow me for this action.
> 
> Since it thinks BitBucket credentials are wrong, clears credentials and this causes the extension wants user to re-login, while credentials were already correct
> 
> https://github.com/billsedison/vscode-gitlens/blob/tc-dev/src/gitCommentService.ts#L610
> https://github.com/billsedison/vscode-gitlens/blob/tc-dev/src/gitCommentService.ts#L661
> 
> I think 
> 
> * Delete and Edit buttons should not be shown if the comment is not added by me, or I'm not the owner (or one of maintainers) of the repo
> 
> or 
> 
> * If we keep them for all comments, extension needs to warn user that he is not allowed for this action, instead of "BitBucket credentials are wrong", and should not clear credentials 
> 
> Btw, I don't know if repo owner or maintainers have the right to delete/edit someone else's comment