### PR TITLE
Fixes #115: Searching by commit hash will return the exact match

### DIFF
--- a/src/ui/search/app.ts
+++ b/src/ui/search/app.ts
@@ -493,17 +493,25 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
         const before = DOM.getElementById<HTMLInputElement>('before')!.value;
         const after = DOM.getElementById<HTMLInputElement>('after')!.value;
         const showMergeCommits = DOM.getElementById<HTMLInputElement>('showMergeCommits')!.checked;
-        this._api.postMessage({
-            type: 'search',
-            search: searchText,
-            branch: this.getBranch(),
-            author: author,
-            sha: searchHash,
-            since: this.getSince(),
-            before: before,
-            after: after,
-            showMergeCommits: showMergeCommits
-        });
+
+        if (searchHash) {
+            this._api.postMessage({
+                type: 'search',
+                sha: searchHash
+            });
+        }
+        else {
+            this._api.postMessage({
+                type: 'search',
+                search: searchText,
+                branch: this.getBranch(),
+                author: author,
+                since: this.getSince(),
+                before: before,
+                after: after,
+                showMergeCommits: showMergeCommits
+            });
+        }
     }
 
     protected getBranch(): string {


### PR DESCRIPTION
Fixes #115 

Current implementation combines all parameters including commit hash, and, if hash value is specified, sets maxCount to 1 so returns only one result/commit.

This may return wrong commit even if you would search by commit hash.

This PR fixes this, searching by commit hash will return exact match.

I have not made any change in the service and done this on the top level (web UI), not to affect future implementations.