### PR TITLE
Handles the forbidden (no permission) case for API endpoints

### DIFF
--- a/src/gitCommentService.ts
+++ b/src/gitCommentService.ts
@@ -532,9 +532,12 @@ export class GitCommentService implements Disposable {
         }
         catch (e) {
             Logger.error(e);
-            if (e!.response!.status === 401 || e!.response!.status === 403) {
+            if (e!.response!.status === 401) {
                 window.showErrorMessage('Incorrect Bit Bucket Service Credentials. Could not add comment/reply.');
                 GitCommentService.ClearCredentials();
+            }
+            else if (e!.response!.status === 403) {
+                window.showErrorMessage('You are not allowed to do this action. Make sure you have permission for this repository.');
             }
             else {
                 console.log(e.response);
@@ -606,9 +609,12 @@ export class GitCommentService implements Disposable {
         }
         catch (e) {
             Logger.error(e);
-            if (e!.response!.status === 401 || e!.response!.status === 403) {
+            if (e!.response!.status === 401) {
                 window.showErrorMessage('Incorrect Bit Bucket Service Credentials. Could not edit comment/reply.');
                 GitCommentService.ClearCredentials();
+            }
+            else if (e!.response!.status === 403) {
+                window.showErrorMessage('You are not allowed to do this action. Make sure you have permission to do this.');
             }
             else {
                 window.showErrorMessage('Failed to add comment/reply.');
@@ -657,9 +663,12 @@ export class GitCommentService implements Disposable {
         }
         catch (e) {
             Logger.error(e);
-            if (e!.response!.status === 401 || e!.response!.status === 403) {
+            if (e!.response!.status === 401) {
                 window.showErrorMessage('Incorrect Bit Bucket Service Credentials. Could not delete comment/reply.');
                 GitCommentService.ClearCredentials();
+            }
+            else if (e!.response!.status === 403) {
+                window.showErrorMessage('You are not allowed to do this action. Make sure you have permission to do this.');
             }
             else {
                 window.showErrorMessage('Failed to delete comment/reply.');


### PR DESCRIPTION
https://gitlab.com/aggregated-git-diff/aggregated-git-diff-bug-bash/issues/92

> One more thing, comment viewer app shows Edit and Delete buttons for all comments. But I'm not allowed to Edit or Delete someone else's comment. So if I try to do this, API returns 401 or 403 and extension thinks BitBucket credentials are wrong but the reality is API endpoint doesn't allow me for this action.
> 
> Since it thinks BitBucket credentials are wrong, clears credentials and this causes the extension wants user to re-login, while credentials were already correct
> 
> https://github.com/billsedison/vscode-gitlens/blob/tc-dev/src/gitCommentService.ts#L610
> https://github.com/billsedison/vscode-gitlens/blob/tc-dev/src/gitCommentService.ts#L661
> 
> I think 
> 
> * Delete and Edit buttons should not be shown if the comment is not added by me, or I'm not the owner (or one of maintainers) of the repo
> 
> or 
> 
> * If we keep them for all comments, extension needs to warn user that he is not allowed for this action, instead of "BitBucket credentials are wrong", and should not clear credentials
> 
> Btw, I don't know if repo owner or maintainers have the right to delete/edit someone else's comment