### PR TITLE
Fixes #118 and #119

### DIFF
--- a/src/annotations/commentsDecoratorController.ts
+++ b/src/annotations/commentsDecoratorController.ts
@@ -25,7 +25,7 @@ export class CommentsDecoratorController implements Disposable {
 
     constructor() {
         this._activeEditor = window.activeTextEditor;
-        if (Container.commentService && Container.commentService.commentCache) {
+        /*if (Container.commentService && Container.commentService.commentCache) {
             this.commentCache = Container.commentService.commentCache;
         }
         if (this._activeEditor) {
@@ -33,18 +33,18 @@ export class CommentsDecoratorController implements Disposable {
                 .catch(e => {
                     console.log(e);
                 });
-        }
+        }*/
 
         this._disposable = Disposable.from(
             window.onDidChangeActiveTextEditor(editor => {
                 this._activeEditor = editor;
-                this.commentCache = Container.commentService.commentCache;
+                /*this.commentCache = Container.commentService.commentCache;
                 if (editor) {
                     this.fetchComments()
                         .catch(e => {
                             console.log(e);
                         });
-                }
+                }*/
             }, null)
         );
     }

--- a/src/annotations/commentsDecoratorController.ts
+++ b/src/annotations/commentsDecoratorController.ts
@@ -123,7 +123,7 @@ export class CommentsDecoratorController implements Disposable {
      * False if decorations of comments will be added.
      */
     updateDecorations(comments: Comment[], removeDecoration = false) {
-        if (!this._activeEditor) {
+        /*if (!this._activeEditor) {
             return;
         }
         for (const comment of comments) {
@@ -143,6 +143,6 @@ export class CommentsDecoratorController implements Disposable {
                 editor.setDecorations(this.bookmarkDecorationType, this.decorations);
                 break;
             }
-        }
+        }*/
     }
 }

--- a/src/commands/addLineComments.ts
+++ b/src/commands/addLineComments.ts
@@ -15,6 +15,16 @@ import { ActiveEditorCachedCommand, Commands, getCommandUri, getRepoPathOrActive
 import * as externalAppController from './externalAppController';
 
 /**
+ * Line number will be sent in To or From field.
+ * See for details:
+ * https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commit/%7Bnode%7D/comments#get
+ */
+export enum lineCommentTypes {
+    To,
+    From
+}
+
+/**
  *Encapsulates infomation to perform comments management command.
  */
 export interface AddLineCommentsCommandArgs {
@@ -27,6 +37,7 @@ export interface AddLineCommentsCommandArgs {
     replyCommand?: CommandQuickPickItem;
     type?: operationTypes;
     isFileComment?: boolean;
+    lineCommentType?: lineCommentTypes;
 }
 
 /**
@@ -89,7 +100,8 @@ export class AddLineCommentCommand extends ActiveEditorCachedCommand {
                     commentArgs.commit!,
                     data.payload as string,
                     commentArgs.fileName as string,
-                    commentArgs.line
+                    commentArgs.line,
+                    commentArgs.lineCommentType
                 );
 
                 // add the new comment in cache
@@ -121,6 +133,7 @@ export class AddLineCommentCommand extends ActiveEditorCachedCommand {
                     data.payload as string,
                     commentArgs.fileName as string,
                     commentArgs.line,
+                    commentArgs.lineCommentType,
                     commentArgs.id
                 );
             }

--- a/src/commands/addLineComments.ts
+++ b/src/commands/addLineComments.ts
@@ -59,6 +59,9 @@ export class AddLineCommentCommand extends ActiveEditorCachedCommand {
     static currentFileName: string;
     static showFileCommitComment: boolean = false;
 
+    static rightDocumentUri: Uri;
+    static leftDocumentUri: Uri;
+
     // required parameters for bitBucketCommentApp
     private eventEmitter: EventEmitter;
     private BITBUCKET_COMMENT_APP_NAME = 'bitbucket-comment-app';
@@ -166,7 +169,7 @@ export class AddLineCommentCommand extends ActiveEditorCachedCommand {
             commentApp = new CommentApp(this.electronPath, this.BITBUCKET_COMMENT_APP_PATH, this.eventEmitter, args);
             commentApp.run();
             commentApp.setUpConnection();
-            commentApp.initEditor(initText)
+            commentApp.initEditor(initText);
         }
     }
 

--- a/src/commands/commentAppHelper.ts
+++ b/src/commands/commentAppHelper.ts
@@ -3,7 +3,7 @@ import * as ipc from 'node-ipc';
 import * as path from 'path';
 import { commands } from 'vscode';
 import { GitCommit } from '../git/git';
-import { Comment, GitCommentService } from '../gitCommentService';
+import { Comment, CommentLine, GitCommentService } from '../gitCommentService';
 import { commentApp, operationTypes } from './addLineComments';
 import { Commands } from './common';
 
@@ -175,7 +175,8 @@ export function initComment(comments: Comment[]) {
                 commands.executeCommand(Commands.AddLineComment, {
                     fileName: GitCommentService.commentViewerFilename,
                     commit: GitCommentService.commentViewerCommit,
-                    line: GitCommentService.commentViewerLine !== -1 ? GitCommentService.commentViewerLine : undefined
+                    line: GitCommentService.commentViewerLine !== -1 ? GitCommentService.commentViewerLine : undefined,
+                    lineCommentType: GitCommentService.lineCommentType
                 });
             }
             else if (data.command === 'ui.ready' && comments) {

--- a/src/commands/diffWith.ts
+++ b/src/commands/diffWith.ts
@@ -5,6 +5,7 @@ import { BuiltInCommands, GlyphChars } from '../constants';
 import { Container } from '../container';
 import { GitCommit, GitService, GitUri } from '../gitService';
 import { Logger } from '../logger';
+import { AddLineCommentCommand } from './addLineComments';
 import { ActiveEditorCommand, Commands } from './common';
 
 export interface DiffWithCommandArgsRevision {
@@ -160,17 +161,19 @@ export class DiffWithCommand extends ActiveEditorCommand {
                 args.showOptions.selection = new Range(args.line, 0, args.line, 0);
             }
 
-            return await commands.executeCommand(
-                BuiltInCommands.Diff,
+            const leftUri: Uri =
                 lhs === undefined
                     ? GitUri.toRevisionUri(GitService.deletedSha, args.lhs.uri.fsPath, args.repoPath)
-                    : lhs,
+                    : lhs;
+            const rightUri: Uri =
                 rhs === undefined
                     ? GitUri.toRevisionUri(GitService.deletedSha, args.rhs.uri.fsPath, args.repoPath)
-                    : rhs,
-                title,
-                args.showOptions
-            );
+                    : rhs;
+
+            AddLineCommentCommand.leftDocumentUri = leftUri;
+            AddLineCommentCommand.rightDocumentUri = rightUri;
+
+            return await commands.executeCommand(BuiltInCommands.Diff, leftUri, rightUri, title, args.showOptions);
         }
         catch (ex) {
             Logger.error(ex, 'DiffWithCommand', 'getVersionedFile');

--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -324,6 +324,16 @@ export class Git {
         return gitCommand({ cwd: root, stdin: stdin }, ...params, '--', file);
     }
 
+    static async blame_revision(
+        repoPath: string | undefined,
+        fileName: string,
+        sha: string
+    ) {
+        const [file, root] = Git.splitPath(fileName, repoPath);
+        const blameParams = [...defaultBlameParams, '-n', sha];
+        return gitCommand({ cwd: root }, ...blameParams, file);
+    }
+
     static async blame_contents(
         repoPath: string | undefined,
         fileName: string,

--- a/src/gitCommentService.ts
+++ b/src/gitCommentService.ts
@@ -6,11 +6,11 @@ import { commands, Disposable, Selection, window, workspace } from 'vscode';
 import { AddLineCommentCommand } from './commands/addLineComments';
 import { initComment, runApp, showComment } from './commands/commentAppHelper';
 import { Commands, getCommandUri } from './commands/common';
+import { CommandContext, setCommandContext } from './constants';
 import { Container } from './container';
 import { GitUri } from './git/gitUri';
 import { GitCommit } from './git/models/commit';
 import { Logger } from './logger';
-import { setCommandContext, CommandContext } from './constants';
 
 /**
  * Enum to for different comment types.
@@ -19,6 +19,18 @@ export enum CommentType {
     File = 'file',
     Line = 'line',
     Commit = 'commit'
+}
+
+/**
+ * To: zero-based line number of the comment (in the new revision)
+ * From: zero-based line number of the comment (in the previous revision)
+ * From is reqired to show/add (or other actions) on deleted lines in the new revision)
+ * Details:
+ * https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commit/%7Bnode%7D/comments#get
+ */
+export class CommentLine {
+    To?: number;
+    From?: number;
 }
 
 /**
@@ -31,6 +43,7 @@ export class Comment {
     Id?: number;
     ParentId?: number;
     Line?: number;
+    LineItem?: CommentLine;
     Path?: string;
     Sha?: string;
     Replies: Comment[] = [];
@@ -199,9 +212,63 @@ export class GitCommentService implements Disposable {
         const editor = window.activeTextEditor;
         const position = editor.selection.active;
 
+        // the commit we're reviewing in the diff view,
+        // or recent commit of file, if it's not diff view
+        let fileCommit: GitCommit | undefined;
+        // previous or new revision of file in diff view
+        // left side: previous, right side: new
+        let revisionCommitSha: string;
+
+        const isLeftSideActive =
+            editor.document.uri.fsPath ===
+                (AddLineCommentCommand.leftDocumentUri && AddLineCommentCommand.leftDocumentUri.fsPath);
+        const isRightSideActive = editor.document.uri.fsPath ===
+                (AddLineCommentCommand.rightDocumentUri && AddLineCommentCommand.rightDocumentUri.fsPath);
+
+        const isDiffView = isLeftSideActive || isRightSideActive;
+
+        if (isDiffView && AddLineCommentCommand.currentFileCommit) {
+            if (isLeftSideActive) {
+                // previous revision
+                revisionCommitSha = AddLineCommentCommand.currentFileCommit.lsha;
+            }
+            else {
+                // new revision
+                revisionCommitSha = AddLineCommentCommand.currentFileCommit.rsha;
+            }
+
+            fileCommit = {
+                sha: AddLineCommentCommand.currentFileCommit.rsha,
+                repoPath: repoPath,
+                fileName: AddLineCommentCommand.currentFileName
+            } as GitCommit;
+        }
+        else {
+            // user is not in the diff view
+            const recentCommitSha = await Container.git.getRecentShaForFile(repoPath, filename);
+            revisionCommitSha = recentCommitSha!;
+            fileCommit = {
+                sha: recentCommitSha,
+                repoPath: repoPath,
+                fileName: filename
+            } as GitCommit;
+        }
+
         const lineState = Container.lineTracker.getState(position.line);
         const commit = lineState !== undefined ? lineState.commit : undefined;
-        if (commit === undefined) return undefined;
+        if (commit === undefined) {
+            window.showWarningMessage('You need to wait a few seconds for blame to annotate the file.');
+            return undefined;
+        }
+
+        const blameSrcLine = commit.lines.find(b => b.line === position.line)!.originalLine;
+        const blameCommitSha = commit.sha;
+
+        const blameForRevision = await Container.git.getBlameForFileRevision(gitUri, revisionCommitSha);
+        const targetLine = blameForRevision!.lines.find(
+            l => l.sha === blameCommitSha && l.originalLine === blameSrcLine
+        );
+        const targetLineNum = targetLine!.line;
 
         await GitCommentService.getCredentials();
         let app;
@@ -213,8 +280,16 @@ export class GitCommentService implements Disposable {
                 GitCommentService.commentViewerActive = false;
             });
         }
-        const allComments = await Container.commentService.loadComments(commit).then(res => (res as Comment[])!);
-        const comments = allComments.filter(c => c.Line! === position.line && c.Path === filename);
+        const allComments = await Container.commentService.loadComments(fileCommit).then(res => (res as Comment[])!);
+        let comments: Comment[];
+        if (commit.sha === revisionCommitSha && !isLeftSideActive) {
+            // added/changed in this revision
+            comments = allComments.filter(c => c.LineItem!.To === targetLineNum && c.Path === filename);
+        }
+        else {
+            comments = allComments.filter(c => c.LineItem!.From === targetLineNum && c.Path === filename);
+        }
+
         GitCommentService.lastFetchedComments = comments;
 
         if (canceled) return;
@@ -225,9 +300,9 @@ export class GitCommentService implements Disposable {
         }
         else showComment(comments);
 
-        GitCommentService.commentViewerCommit = commit;
+        GitCommentService.commentViewerCommit = fileCommit;
         GitCommentService.commentViewerFilename = filename;
-        GitCommentService.commentViewerLine = position.line;
+        GitCommentService.commentViewerLine = targetLineNum;
 
         return;
     }
@@ -346,8 +421,13 @@ export class GitCommentService implements Disposable {
                                 // If comment is a file comment, there is no inline field.
                                 // Therefore it enters the catch block with above usage.
                                 // this prevents the rest of comments from being loaded
-                                if (c.inline && c.inline.to && c.inline.to > 0) {
-                                    comment.Line = c.inline.to - 1;
+                                if (c.inline) {
+                                    comment.Line = c.inline.to > 0 ? c.inline.to - 1 : undefined;
+                                    // Line.To = comment is the new revision of file
+                                    // Line.From = comment is at the previous revision of file
+                                    comment.LineItem = new CommentLine();
+                                    comment.LineItem.To = c.inline.to > 0 ? c.inline.to - 1 : undefined;
+                                    comment.LineItem.From = c.inline.from > 0 ? c.inline.from - 1 : undefined;
                                     comment.Type = CommentType.Line;
                                 }
                                 else {
@@ -490,8 +570,8 @@ export class GitCommentService implements Disposable {
               };
 
         try {
-            Logger.log('POST ' + url );
-            Logger.log('POST DATA ' + JSON.stringify(data) );
+            Logger.log('POST ' + url);
+            Logger.log('POST DATA ' + JSON.stringify(data));
 
             const response = await Axios.create({ auth: auth }).post(url, data);
             window.showInformationMessage('Comment/reply added successfully.');
@@ -548,7 +628,9 @@ export class GitCommentService implements Disposable {
                 GitCommentService.ClearCredentials();
             }
             else if (e!.response!.status === 403) {
-                window.showErrorMessage('You are not allowed to do this action. Make sure you have permission for this repository.');
+                window.showErrorMessage(
+                    'You are not allowed to do this action. Make sure you have permission for this repository.'
+                );
             }
             else {
                 console.log(e.response);
@@ -589,7 +671,7 @@ export class GitCommentService implements Disposable {
                   comment_id: commentId
               };
         try {
-            Logger.log('POST ' + url );
+            Logger.log('POST ' + url);
             Logger.log('POST DATA ' + JSON.stringify(data));
             const v = await Axios.create({ auth: auth }).put(url, data);
             window.showInformationMessage('Comment/reply edited successfully.');
@@ -625,7 +707,9 @@ export class GitCommentService implements Disposable {
                 GitCommentService.ClearCredentials();
             }
             else if (e!.response!.status === 403) {
-                window.showErrorMessage('You are not allowed to do this action. Make sure you have permission to do this.');
+                window.showErrorMessage(
+                    'You are not allowed to do this action. Make sure you have permission to do this.'
+                );
             }
             else {
                 window.showErrorMessage('Failed to add comment/reply.');
@@ -649,7 +733,7 @@ export class GitCommentService implements Disposable {
         const url = `${baseUrl}/${path}/${commitStr}/${sha}/comments/${commentId}`;
 
         try {
-            Logger.log('DELETE ' + url );
+            Logger.log('DELETE ' + url);
             const v = await Axios.create({ auth: auth }).delete(url);
             window.showInformationMessage('Comment/reply deleted successfully.');
             if (GitCommentService.lastFetchedComments) {
@@ -679,7 +763,9 @@ export class GitCommentService implements Disposable {
                 GitCommentService.ClearCredentials();
             }
             else if (e!.response!.status === 403) {
-                window.showErrorMessage('You are not allowed to do this action. Make sure you have permission to do this.');
+                window.showErrorMessage(
+                    'You are not allowed to do this action. Make sure you have permission to do this.'
+                );
             }
             else {
                 window.showErrorMessage('Failed to delete comment/reply.');
@@ -687,7 +773,7 @@ export class GitCommentService implements Disposable {
         }
     }
 
-    async retrieveParticipants (str: string) {
+    async retrieveParticipants(str: string) {
         const url = 'https://bitbucket.org/xhr/user-mention';
         const requestParams = {
             term: str

--- a/src/gitService.ts
+++ b/src/gitService.ts
@@ -722,6 +722,27 @@ export class GitService implements Disposable {
         }
     }
 
+    async getBlameForFileRevision(
+        uri: GitUri,
+        sha: string
+    ): Promise<GitBlame | undefined> {
+        if (!(await this.isTracked(uri))) {
+            Logger.log(`Skipping blame; '${uri.fsPath}' is not tracked`);
+            return GitService.emptyPromise as Promise<GitBlame>;
+        }
+
+        const [file, root] = Git.splitPath(uri.fsPath, uri.repoPath, false);
+
+        try {
+            const data = await Git.blame_revision(root, file, sha);
+            const blame = GitBlameParser.parse(data, root, file, await this.getCurrentUser(root));
+            return blame;
+        }
+        catch (ex) {
+            return undefined;
+        }
+    }
+
     async getBlameForLine(
         uri: GitUri,
         line: number,


### PR DESCRIPTION
Fixes #118 #119 

- [x] [getBlameForFileRevision](https://github.com/billsedison/vscode-gitlens/pull/121/files#diff-7e656fadca6b02e779f1bb9d3ce09c02R725) and [blame_revision](https://github.com/billsedison/vscode-gitlens/pull/121/files#diff-a46dd2f89f5b59bb98053c6acf84e2a3R327) functions have been implemented, in order to get blame data of lines for specific revisions/commits.
- [x] Even though line numbers are different (document has changes), the target line will be detected correctly.
- [x] [CommentLine](https://github.com/billsedison/vscode-gitlens/pull/121/files#diff-75b693d7b13f5124c3a7e6fb6b11eea2R31), which has **To** and **From** fields, has been implemented. 

  *  [Details about BitBucket API `comments` endpoint](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commit/%7Bnode%7D/comments#get)  
    
       *  **to**:
      > The comment's anchor line in the new version of the file.
      *  **from**:
      > The comment's anchor line in the old version of the file.

  *  It was adding and getting all comments in/from **to** field before, now it detects the field which should be used, and sends/gets the line number within it. This field is important if you'll add/show (or other actions) on a deleted/added/changed line.
  *  To understand the difference and importance of these fields, see the screencast.

![2019-01-04_03-43-27](https://user-images.githubusercontent.com/28513447/50668920-339db380-0fd3-11e9-9c97-682eb48e24d2.gif)

  *  **NOTE:** There are still some parts using the `Line` field of `Comment` Therefore we're keeping it for now, not to cause any issue in other parts

- [x] Line decorations for comments temporarily disabled until #120 and compatibility issues (with this PR) fixed

### TESTED CASES

For your reference. Below cases tested on my side and haven't had any issue.

* In the edit mode (not the DiffView)
  *  Show/Add/Delete/Edit/Reply on any line from old commits (take blame annotation as reference)
  *  Show/Add/Delete/Edit/Reply on a line that is affected by the current commit. (take blame annotation as reference)
    **Note:** In the Edit mode, Current commit is the last commit that made a change on this file
  *  Repeat above cases on the BitBucket website and check if VSCode side is fully compatible.
  *  Make a change in the file, that changes the line numbers from above steps.
  *  Repeat above cases.
* In the DiffView (Commit Search -> Select a commit -> Select a file)
  *  On the right side (the revision/commit we're reviewing)
     *  Select an unchanged (neither coloured as green nor red) line and Show/Add/Edit/Reply/Delete functionalities. Check BitBucket side to see all functions are working and affecting well on both sides
     *  Select a line changed or added (green) in this revision and check the above functionalities on both sides.
  *  On the left side (previous revision to compare changes)
     *  Select an unchanged (neither coloured as green nor red) line and Show/Add/Edit/Reply/Delete functionalities. Check BitBucket side to see all functions are working and affecting well on both sides.
     *  Select a line deleted (red) in the new revision and check the above functionalities on both sides.

Your actions should affect only the related line, even if their line numbers would be same.

### KNOWN ISSUE

In case of multiple DiffViews are opened, only the last one will work properly with the existing code. So I have not fixed it and went with the same way that the existing code uses. Let me know if we need to fix this