### PR TITLE
Fixed some issues with webpack.config for welcome.html

### DIFF
--- a/src/ui/welcome/index.html
+++ b/src/ui/welcome/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-    </head>
+    <link href="{{root}}/dist/ui/welcome.css" rel="stylesheet"></head>
 
     <body class="preload">
         <!-- <canvas class="snow"></canvas>
@@ -79,6 +79,15 @@
                             >User Settings</a
                         >.
                     </p>
+                    <p>
+                        This is an
+                        <a class="bold" title="Learn more about Extended version" href="https://github.com/billsedison/vscode-gitlens">Extended version</a>
+                        version of the
+                        <a class="bold" title="Learn more about Original GitLens" href="https://gitlens.amod.io">GitLens</a>,
+                        has been developed by the
+                        <a class="bold" title="Learn more about TopCoder" href="https://topcoder.com">TopCoder</a>
+                        community, for BitBucket integration.
+                    </p>
                 </div>
 
                 <div class="cta__container center">
@@ -103,6 +112,32 @@
 
                 <div class="section-groups">
                     <div class="section-group__content">
+                        <section class="section-group-section changelog">
+                            <h2 class="changelog__title">
+                                What's New in <span class="changelog__version">Extended GitLens</span>
+                            </h2>
+                            <ul class="changelog__list">
+                                <li>
+                                    <span class="changelog__badge changelog__badge--added">NEW</span>BitBucket Integration
+                                    <div class="changelog__details changelog__details--list">
+                                        <p>
+                                            <b>* File-level Comments</b> &mdash; quick comment operations within VSCode.
+                                        </p>
+                                        <p>
+                                            <b>* Inline Comments</b> &mdash; quick comment operations within VSCode.
+                                        </p>
+                                    </div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--added">NEW</span>Advanced Markdown Editor for comments
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--changed">IMPROVED</span>Commit Search
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                            </ul>
+                        </section>
                         <section id="whats-new" class="section-group-section changelog">
                             <h2 class="changelog__title">
                                 What's New in <span class="changelog__version">GitLens 9</span>
@@ -130,6 +165,165 @@
 
                             <ul class="changelog__list">
                                 <li>
+                                    <span class="changelog__badge changelog__badge--version">9.5</span>
+                                    <span class="changelog__date">FEB &nbsp;2019</span>
+                                    <div class="changelog__details"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--added">NEW</span>Adds a
+                                    <code>mailto:</code> link to the author on the <i>commit details</i> hover &mdash;
+                                    closes
+                                    <a
+                                        title="Open Issue #642"
+                                        href="https://github.com/eamodio/vscode-gitlens/issues/642"
+                                        >#642</a
+                                    >
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--added">NEW</span>Adds support for
+                                    customizing the layout of the <i>commit details</i> hover
+                                    <div class="changelog__details changelog__details--list">
+                                        <p>
+                                            Adds a <code>gitlens.hovers.detailsMarkdownFormat</code> setting to specify
+                                            the format (in markdown) of the <i>commit details</i> hover
+                                        </p>
+                                    </div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--added">NEW</span>Adds the author's
+                                    e-mail to the tooltip of commits in the views &mdash; closes
+                                    <a
+                                        title="Open Issue #642"
+                                        href="https://github.com/eamodio/vscode-gitlens/issues/642"
+                                        >#642</a
+                                    >
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--added">NEW</span>Adds a new author
+                                    e-mail format token (<code>&#36;{email}</code>) &mdash; closes
+                                    <a
+                                        title="Open Issue #642"
+                                        href="https://github.com/eamodio/vscode-gitlens/issues/642"
+                                        >#642</a
+                                    >
+                                    <div class="changelog__details changelog__details--list">
+                                        <p>
+                                            Supported in the following settings: <code>gitlens.blame.format</code>,
+                                            <code>gitlens.currentLine.format</code>,
+                                            <code>gitlens.hovers.detailsMarkdownFormat</code>,
+                                            <code>gitlens.views.commitFormat</code>,
+                                            <code>gitlens.views.commitDescriptionFormat</code>,
+                                            <code>gitlens.views.stashFormat</code>,
+                                            <code>gitlens.views.stashDescriptionFormat</code>, and
+                                            <code>gitlens.statusBar.format</code>
+                                        </p>
+                                    </div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--changed">IMPROVED</span>Changes the
+                                    sorting of remotes in the <i>Repositories</i> view to sort the default remote first
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--changed">IMPROVED</span>Changes
+                                    relative date formatting of the last fetched date of repositories in the
+                                    <i>Repositories</i> view to instead use an absolute format and will additionally add
+                                    the time of day if less than a day has passed
+                                    <div class="changelog__details changelog__details--list">
+                                        <p>
+                                            This avoids having to periodically refresh the repository (which causes all
+                                            of its children to re-render) in order to update the relative time
+                                        </p>
+                                    </div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--fixed">FIXED</span>Fixes
+                                    <a
+                                        title="Open Issue #591"
+                                        href="https://github.com/eamodio/vscode-gitlens/issues/591"
+                                        >#591</a
+                                    >
+                                    &mdash; GitLens Error: Unable to opens
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--fixed">FIXED</span>Fixes
+                                    <a
+                                        title="Open Issue #620"
+                                        href="https://github.com/eamodio/vscode-gitlens/issues/620"
+                                        >#620</a
+                                    >
+                                    &mdash; Wrong URL to open commit on Azure DevOps if cloned via SSH &mdash; thanks to
+                                    <a
+                                        title="Open Pull Request #621"
+                                        href="https://github.com/eamodio/vscode-gitlens/pull/621"
+                                        >PR #621</a
+                                    >
+                                    by Yan Zhang (<a title="@Eskibear" href="https://github.com/Eskibear">@Eskibear</a>)
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--fixed">FIXED</span>Fixes
+                                    <a
+                                        title="Open Issue #626"
+                                        href="https://github.com/eamodio/vscode-gitlens/issues/626"
+                                        >#626</a
+                                    >
+                                    &mdash; Branch names with only digits always appear first &mdash; thanks to
+                                    <a
+                                        title="Open Pull Request #627"
+                                        href="https://github.com/eamodio/vscode-gitlens/pull/627"
+                                        >PR #627</a
+                                    >
+                                    by Marc Lasson (<a title="@mlasson" href="https://github.com/mlasson">@mlasson</a>)
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--fixed">FIXED</span>Fixes
+                                    <a
+                                        title="Open Issue #631"
+                                        href="https://github.com/eamodio/vscode-gitlens/issues/631"
+                                        >#631</a
+                                    >
+                                    &mdash; Remotes fail to show in gui
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--fixed">FIXED</span>Fixes
+                                    <a
+                                        title="Open Issue #633"
+                                        href="https://github.com/eamodio/vscode-gitlens/issues/633"
+                                        >#633</a
+                                    >
+                                    &mdash; Compare File with Previous Revision doesn't work if path contains '#'
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--fixed">FIXED</span>Fixes
+                                    <a
+                                        title="Open Issue #635"
+                                        href="https://github.com/eamodio/vscode-gitlens/issues/635"
+                                        >#635</a
+                                    >
+                                    &mdash; Show more commit not working properly
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--fixed">FIXED</span>Fixes an issue
+                                    where the <i>Open File</i>, <i>Open File on Remote</i>, and
+                                    <i>Copy Remote Url to Clipboard</i> commands didn't always work on changed files in
+                                    the <i>Repositories</i> view
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+                                <li>
+                                    <span class="changelog__badge changelog__badge--fixed">FIXED</span>Fixes an issue
+                                    where the default remote wasn't used first to provide automatic issue linking
+                                    <div class="changelog__details changelog__details--list"></div>
+                                </li>
+
+                                <li class="changelog__list-item--version">
                                     <span class="changelog__badge changelog__badge--version">9.4</span>
                                     <span class="changelog__date">JAN &nbsp;2019</span>
                                     <div class="changelog__details"></div>
@@ -913,7 +1107,7 @@
                     </div>
                     <div class="section-group__sidebar section-group__sidebar--welcome">
                         <div class="sidebar-group">
-                            <h2>Sponsors</h2>
+                            <h2>Sponsored by</h2>
                             <a
                                 title="Try CodeStream"
                                 href="https://codestream.com/?utm_source=gitlens_welcome&utm_medium=banner&utm_campaign=gitlens"
@@ -921,19 +1115,19 @@
                                 <!-- prettier-ignore-attribute src -->
                                 <img
                                     class="sponsor__image light"
-                                    src="{{root}}/images/sponsors/codestream-vertical-light.png"
+                                    src="https://alt-images.codestream.com/codestream_logo_gitlens_welcome_dark.png"
                                     alt="CodeStream Logo"
                                 />
                                 <!-- prettier-ignore-attribute src -->
                                 <img
                                     class="sponsor__image dark"
-                                    src="{{root}}/images/sponsors/codestream-vertical-dark.png"
+                                    src="https://alt-images.codestream.com/codestream_logo_gitlens_welcome_light.png"
                                     alt="CodeStream Logo"
                                 />
                             </a>
                             <p class="sponsor__tag">
-                                CodeStream enables continuous code review by putting team chat in VS Code. Save
-                                discussions about code with your code. Integrates w/Slack.
+                                Discuss, review, and share code with your team in VS Code. Links discussions about code
+                                to your code. Integrates w/ Slack, Jira, Trello, and Live Share.
                             </p>
 
                             <h2 name="#support-gitlens">Show Your Support &nbsp;&#x2764;</h2>
@@ -1042,5 +1236,5 @@
         <script type="text/javascript">
             window.bootstrap = '{{bootstrap}}';
         </script>
-    </body>
+    <script type="text/javascript" src="{{root}}/dist/ui/welcome.js"></script></body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -159,12 +159,11 @@ function getUIConfig(env) {
             filename: '[name].css'
         }),
         new HtmlPlugin({
-            excludeChunks: ['welcome','settings'],
+            excludeChunks: ['welcome'],
             template: 'settings/index.html',
             filename: path.resolve(__dirname, 'settings.html'),
             inject: true,
             inlineSource: env.production ? '.(js|css)$' : undefined,
-            // inlineSource: '.(js|css)$',
             minify: env.production
                 ? {
                       removeComments: true,
@@ -173,14 +172,15 @@ function getUIConfig(env) {
                       useShortDoctype: true,
                       removeEmptyAttributes: true,
                       removeStyleLinkTypeAttributes: true,
-                      keepClosingSlash: true
+                      keepClosingSlash: true,
+                      minifyCSS: true
                   }
                 : false
         }),
         new HtmlPlugin({
-            excludeChunks: ['welcome'],
-            template: 'settings/index.html',
-            filename: path.resolve(__dirname, 'settings.html'),
+            excludeChunks: ['settings'],
+            template: 'welcome/index.html',
+            filename: path.resolve(__dirname, 'welcome.html'),
             inject: true,
             inlineSource: env.production ? '.(js|css)$' : undefined,
             minify: env.production


### PR DESCRIPTION
- [x] The old (v8.5.6) `welcome.html` page replaced by the new one. (v9.5)
- [x] Made some modifications in the `welcome.html`, to introduce this extended version.
- [x] Added the missing entry (which is preventing the page from being created during the build) for the `welcome.html` in `webpack.config.js`
- [x] Removed an unnecessary (duplicate) entry for `settings.html` from `webpack.config.js`

https://gitlab.com/aggregated-git-diff/aggregated-git-diff-bug-bash/issues/104

> The [original GitLens extension](https://github.com/eamodio/vscode-gitlens) shows **welcome.html** on first-time installation, or when a new update installed. Its basically a file that introduces the extension (or changelog for the installed update).
> 
> There is no **welcome.html** in the [current branch](https://github.com/billsedison/vscode-gitlens/tree/tc-dev-merge-to-9.4.1), this is causing console errors.
> 
> **Steps to Reproduce** 
> 
> 1. Clone/checkout the [tc-dev-merge-to-9.4.1](https://github.com/billsedison/vscode-gitlens/tree/tc-dev-merge-to-9.4.1) branch.
> 2. Run
> ```sh..
> npm install
> npm run build
> ```
> 3. Open the root directory of project with VSCode.
> 4. Start debugging (Press F5) and wait for the extension to be activated.
> 5. On the VSCode window, Go to the **Help -> Toggle Developer Tools**
> 6. On the console view, to the **Console** section.
> 
> **Expected Result**
> 
> This file should not cause any warning/error.
> 
> **Actual Result**
> 
> Since this file cannot be found, its causing errors on the console.
> 
> **Possible Fix**
> 
> * A welcome page specific to this extended version can be prepared. In this case, just naming it as `welcome.html` will be enough. The extension should show it on first-time installation or on an update.