### PR TITLE
Comment Operations Don't Work

### DIFF
--- a/src/commands/addLineComments.ts
+++ b/src/commands/addLineComments.ts
@@ -11,7 +11,7 @@ import { CommandQuickPickItem, CommentsQuickPick } from '../quickpicks';
 import { Strings } from '../system';
 import { ShowDiffMessage } from '../ui/ipc';
 import { CommentApp } from './commentAppController';
-import { ActiveEditorCachedCommand, Commands, getCommandUri, getRepoPathOrActiveOrPrompt } from './common';
+import {ActiveEditorCachedCommand, command, Commands, getCommandUri, getRepoPathOrActiveOrPrompt} from './common';
 import * as externalAppController from './externalAppController';
 
 /**
@@ -45,6 +45,7 @@ export let commentApp: CommentApp;
 /**
  * Command to add/edit/delete/reply an inline or file comment.
  */
+@command()
 export class AddLineCommentCommand extends ActiveEditorCachedCommand {
     /**
      * Gets markdown for command with given argumants.

--- a/src/commands/bitBucketServiceAuth.ts
+++ b/src/commands/bitBucketServiceAuth.ts
@@ -2,11 +2,12 @@
 import { CancellationTokenSource,  InputBoxOptions, window } from 'vscode';
 import { GitCommentService } from '../gitCommentService';
 import { Logger } from '../logger';
-import { ActiveEditorCachedCommand, Commands } from './common';
+import {ActiveEditorCachedCommand, command, Commands} from './common';
 
 /**
  * Command to prompt user for Bitbucket service credentials.
  */
+@command()
 export class BitBucketServiceAuthCommand extends ActiveEditorCachedCommand {
     constructor() {
         super(Commands.BitBuckerServiceAuth);


### PR DESCRIPTION
The comment operations don't work at all. (adding/replying/deleting/editing)

**Steps to Reproduce** 

1. Clone/checkout the [tc-dev-merge-to-9.4.1](https://github.com/billsedison/vscode-gitlens/tree/tc-dev-merge-to-9.4.1) branch.
2. Run
```sh..
npm install
npm run build
```
3. Open the root directory of project with VSCode.
4. Start debugging (Press F5)
5. If its not open, open a file in the editor. (you may have to wait for a couple of seconds for activation)
6. Select/click any line from the file
7. Click on the **Blue icon/button** at the right-top corner, to open up the Comment Viewer app.
8. Login to BitBucket if necessary
7. On the Comment Viewer app. window, try to do some comment actions.

**Expected Result**

Comment operations should properly work.

**Actual Result**

Comment operations don't work at all.

**Additional Context**

If you check the console output, we're getting the following error.

```js
ERR command 'gitlens.manageComments' not found: Error: command 'gitlens.manageComments' not found
```

I have not yet deeply investigated this, but, my guess is, probably new version overrides (or renames) some of our specific commands. If this is the case, you should add the `gitlens.manageComments` (and related functions) from the `tc-dev` branch. 

So have a look at `commands.ts`