### PR TITLE
Commit Search view cannot be opened

### DIFF
--- a/src/ui/search/app.ts
+++ b/src/ui/search/app.ts
@@ -285,7 +285,7 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
                 const files = commit._fileName.split(',') as string[];
                 for (const file of files) {
                     const trimmedFilePath = file.trim();
-                    const status = commit.fileStatuses.filter(
+                    const status = commit.files.filter(
                         (x: any) => (x.fileName as string) === trimmedFilePath
                     );
                     const fileCommitInfo = {
@@ -638,12 +638,12 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
         if (Array.isArray(commit)) {
             commit.forEach(singleCommit => {
                 tempCommit = singleCommit;
-                singleCommit.fileStatuses.map(addnode);
+                singleCommit.files.map(addnode);
             });
         }
         else {
             tempCommit = commit;
-            commit.fileStatuses.map(addnode);
+            commit.files.map(addnode);
         }
 
         return tree;


### PR DESCRIPTION
Commit Search view cannot be opened

**Steps to Reproduce** 

1. Clone/checkout the [tc-dev-merge-to-9.4.1](https://github.com/billsedison/vscode-gitlens/tree/tc-dev-merge-to-9.4.1) branch.
2. Run
```sh..
npm install
npm run build
```
3. Open the root directory of project with VSCode.
4. Start debugging (Press F5)
5. On the left tab, Click on the `GitLens` logo.
6. Find the **Search** icon and click on it.

**Expected Result**

Commit Search view should be opened. You can check it out on `tc-dev` branch

**Actual Result**

We can't open the Commit Search view

**Additional Context**

If you check the console output, we're getting the following error.

```js
[2019-02-13 10:32:58:414] ShowCommitSearchCommand
TypeError: Cannot read property 'webview' of undefined
```

Take a look at **Additional Context** section of #105. Probably a similar  case again.

One thing to note here, **Commit Search** view is a specific view/page for this extended version. (you can check it on `tc-dev` branch) But, *as far as I understand*, v9.4.1 of original GitLens extension uses a different approach for commit search.

So if its preferred to keep the old functionality as it is, the old (from `tc-dev`) commands and functions should be used again.