### PR TITLE
Fixed: Login and logout buttons for BitBucket are now visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -3916,12 +3916,12 @@
         },
         {
           "command": "gitlens.bitbucket.login",
-          "when": "view =~ /^gitlens.gitExplorer:/ && !gitlens:bitbucketLoggedIn",
+          "when": "view =~ /^gitlens.views.repositories:/ && !gitlens:bitbucketLoggedIn",
           "group": "3_gitlens"
         },
         {
           "command": "gitlens.bitbucket.logout",
-          "when": "view =~ /^gitlens.gitExplorer:/ && gitlens:bitbucketLoggedIn",
+          "when": "view =~ /^gitlens.views.repositories:/ && gitlens:bitbucketLoggedIn",
           "group": "3_gitlens"
         },
         {


### PR DESCRIPTION
- [x] Fixed an issue that was preventing **Login to BitBucket** and **Logout** buttons from being shown on the menu. They're now visible.

![bitbucket-login](https://user-images.githubusercontent.com/28513447/53424273-f6163f00-39f3-11e9-873d-5fccdf3f951e.jpg)
