### PR TITLE
Fixed: Commit Search view can now be opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -4025,7 +4025,7 @@
           "group": "1_gitlens"
         },
         {
-          "command": "gitlens.views.search.searchCommits",
+          "command": "gitlens.showSearchPage",
           "when": "view =~ /^gitlens\\.views\\.search:/",
           "group": "navigation@10"
         },
@@ -4470,11 +4470,6 @@
           "group": "7_gitlens_more@1"
         },
         {
-          "command": "gitlens.showSearchPage",
-          "when": "viewItem =~ /gitlens:repository\\b/",
-          "group": "inline@10"
-        },
-        {
           "command": "gitlens.views.star",
           "when": "viewItem =~ /gitlens:repository\\b(?!.*?\\+starred\\b.*?)/",
           "group": "inline@1"
@@ -4529,11 +4524,6 @@
           "command": "gitlens.openRepoInRemote",
           "when": "viewItem =~ /gitlens:repository\\b/ && gitlens:hasRemotes",
           "group": "2_gitlens@2"
-        },
-        {
-          "command": "gitlens.showSearchPage",
-          "when": "viewItem =~ /gitlens:repository\\b/",
-          "group": "3_gitlens@1"
         },
         {
           "command": "gitlens.stashApply",
@@ -4632,12 +4622,12 @@
           "group": "2_gitlens@2"
         },
         {
-          "command": "gitlens.views.search.searchCommits",
+          "command": "gitlens.showSearchPage",
           "when": "viewItem == gitlens:search:results",
           "group": "inline@1"
         },
         {
-          "command": "gitlens.views.search.searchCommits",
+          "command": "gitlens.showSearchPage",
           "when": "viewItem == gitlens:search:results",
           "group": "2_gitlens@1"
         },

--- a/src/ui/search/app.ts
+++ b/src/ui/search/app.ts
@@ -285,7 +285,7 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
                 const files = commit._fileName.split(',') as string[];
                 for (const file of files) {
                     const trimmedFilePath = file.trim();
-                    const status = commit.fileStatuses.filter(
+                    const status = commit.files.filter(
                         (x: any) => (x.fileName as string) === trimmedFilePath
                     );
                     const fileCommitInfo = {
@@ -638,12 +638,12 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
         if (Array.isArray(commit)) {
             commit.forEach(singleCommit => {
                 tempCommit = singleCommit;
-                singleCommit.fileStatuses.map(addnode);
+                singleCommit.files.map(addnode);
             });
         }
         else {
             tempCommit = commit;
-            commit.fileStatuses.map(addnode);
+            commit.files.map(addnode);
         }
 
         return tree;


### PR DESCRIPTION
- [x] Fixed: Commit Search page can now be opened.
  *  The main issue was, original GitLens extension uses its own Commit Search function (`gitlens.views.search.searchCommits`) and button (Search icon). So, that button/icon was actually triggering their function, instead of our specific `gitlens.showSearchPage` function.
  * `gitlens.views.search.searchCommits` function replaced by our specific `gitlens.showSearchPage` function.
- [x] Fixed an issue that was preventing search results from being loaded, after the Commit Search page opened.

https://gitlab.com/aggregated-git-diff/aggregated-git-diff-bug-bash/issues/106

> Commit Search view cannot be opened
> 
> **Steps to Reproduce** 
> 
> 1. Clone/checkout the [tc-dev-merge-to-9.4.1](https://github.com/billsedison/vscode-gitlens/tree/tc-dev-merge-to-9.4.1) branch.
> 2. Run
> ```sh..
> npm install
> npm run build
> ```
> 3. Open the root directory of project with VSCode.
> 4. Start debugging (Press F5)
> 5. On the left tab, Click on the `GitLens` logo.
> 6. Find the **Search** icon and click on it.
> 
> **Expected Result**
> 
> Commit Search view should be opened. You can check it out on `tc-dev` branch
> 
> **Actual Result**
> 
> We can't open the Commit Search view
> 
> **Additional Context**
> 
> If you check the console output, we're getting the following error.
> 
> ```js
> [2019-02-13 10:32:58:414] ShowCommitSearchCommand
> TypeError: Cannot read property 'webview' of undefined
> ```
> 
> Take a look at **Additional Context** section of #105. Probably a similar  case again.
> 
> One thing to note here, **Commit Search** view is a specific view/page for this extended version. (you can check it on `tc-dev` branch) But, *as far as I understand*, v9.4.1 of original GitLens extension uses a different approach for commit search.
> 
> So if its preferred to keep the old functionality as it is, the old (from `tc-dev`) commands and functions should be used again.