### PR TITLE
Fixed: Commit Search will not use __lastSearch for next searches

### DIFF
--- a/src/commands/searchCommits.ts
+++ b/src/commands/searchCommits.ts
@@ -117,9 +117,9 @@ export class SearchCommitsCommand extends ActiveEditorCachedCommand {
                     args.search = searchByToSymbolMap.get(args.searchBy);
                     selection = [1, 1];
                 }
-                else {
+                /*else {
                     args.search = this._lastSearch;
-                }
+                }*/
             }
 
             if (args.showInView) {


### PR DESCRIPTION
- [x] __lastSearch will no longer be used for next searches.

https://gitlab.com/aggregated-git-diff/aggregated-git-diff-bug-bash/issues/110

> After doing a successful search, its returning the same (the previous) results for next searches.
> 
> **Steps to Reproduce** 
> 1. Clone/checkout the [tc-dev-merge-to-9.4.1](https://github.com/billsedison/vscode-gitlens/tree/tc-dev-merge-to-9.4.1) branch.
> 2. Run
> ```sh..
> npm install
> npm run build
> ```
> 3. Open the root directory of project with VSCode.
> 4. Start debugging (Press F5)
> 5. Open the Command Palette by pressing `Ctrl+Shift+P`, and select the `GitLens: Search Commits` command.
>     * All commits should be listed on the left panel.
> 6. Enter a keyword in the *enter search text* field, and click *Search*.
>     * The correct search results (related to keyword) should be shown on the left panel.
> 7. Delete the keyword (i.e. clear the *enter search text* field) and Search again.
> 8. Check the results.
> 
> 
> **Expected Result**
> 
> Correct results should be returned.
> 
> **Actual Result**
> 
> The previous search results are being returned for next searches.
> 
> **Screencast**
> 
> ![2019-02-27_00-38-54](/uploads/17691266b96da0c31ada6da43fbf747a/2019-02-27_00-38-54.mp4)