### PR TITLE
Fixed Commit Search View: Details section will not be resetted when tab changed

### DIFF
--- a/src/ui/search/app.ts
+++ b/src/ui/search/app.ts
@@ -123,7 +123,7 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
                 searchMessage.innerText = event.data.searchLabel;
                 return;
             }
-            if (event.data.type === 'showDiff') {
+            if (event.data.type === 'showDiff' || event.data.type === 'settingsChanged') {
                 return;
             }
 
@@ -285,7 +285,7 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
                 const files = commit._fileName.split(',') as string[];
                 for (const file of files) {
                     const trimmedFilePath = file.trim();
-                    const status = commit.fileStatuses.filter(
+                    const status = commit.files.filter(
                         (x: any) => (x.fileName as string) === trimmedFilePath
                     );
                     const fileCommitInfo = {
@@ -638,12 +638,12 @@ export class CommitSearches extends App<CommitSearchBootstrap> {
         if (Array.isArray(commit)) {
             commit.forEach(singleCommit => {
                 tempCommit = singleCommit;
-                singleCommit.fileStatuses.map(addnode);
+                singleCommit.files.map(addnode);
             });
         }
         else {
             tempCommit = commit;
-            commit.fileStatuses.map(addnode);
+            commit.files.map(addnode);
         }
 
         return tree;


### PR DESCRIPTION
- [x] Details section of Commit Search page will not be resetted if the received msg type is 'settingsChanged'

https://gitlab.com/aggregated-git-diff/aggregated-git-diff-bug-bash/issues/109

> Selected commits' file tree and commit details get removed from the right panel, after the tab changed.
> 
> **Steps to Reproduce**
> 
> 1. Clone/checkout the [tc-dev-merge-to-9.4.1](https://github.com/billsedison/vscode-gitlens/tree/tc-dev-merge-to-9.4.1) branch.
> 2. Run
> ```sh..
> npm install
> npm run build
> ```
> 3. Open the root directory of project with VSCode.
> 4. Start debugging (Press F5)
> 5. Open the Command Palette by pressing `Ctrl+Shift+P`, and select the `GitLens: Search Commits` command.
> 6. Select one or several commits from the left panel. 
>     * File names and commit details should be listed on the right panel.
> 7. On the right side, click on any file to open the diff window. (or change the active tab)
> 8. Close the diff window. (or return to the previous tab -- Commit Search page)
> 9. Check the right panel.
> 
> 
> **Expected Result**
> 
> File tree and commit details should be preserved on the right side, after the tab changed. 
> 
> **Actual Result**
> 
> File tree and commit details don't get preserved. We see the right panel empty after changed the tab.
> 
> **Screencast**
> 
> ![2019-02-27_00-55-55](/uploads/04f5e74debfd8facd8abf572d64d5b96/2019-02-27_00-55-55.mp4)